### PR TITLE
Mejoras de uso diario

### DIFF
--- a/odoo_env/__init__.py
+++ b/odoo_env/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.10.22'
+__version__ = '0.10.23'

--- a/odoo_env/client.py
+++ b/odoo_env/client.py
@@ -105,6 +105,7 @@ class Client(object):
 
     def check_common(self, manifest):
         self._port = manifest.get('port', 8069)
+        self._longpolling_port = manifest.get('longpolling_port', 8072)
 
         ver = manifest.get('version')
         if not ver:
@@ -224,6 +225,10 @@ class Client(object):
     @property
     def port(self):
         return self._port
+
+    @property
+    def longpolling_port(self):
+        return self._longpolling_port
 
     @property
     def version_dir(self):

--- a/odoo_env/client.py
+++ b/odoo_env/client.py
@@ -106,7 +106,7 @@ class Client(object):
     def check_common(self, manifest):
         self._port = manifest.get('port', 8069)
         self._longpolling_port = manifest.get('longpolling_port', 8072)
-
+        self._external_dependencies = manifest.get('external_dependencies', {})
         ver = manifest.get('version')
         if not ver:
             msg.err('No version tag in manifest %s' % self.name)
@@ -218,6 +218,10 @@ class Client(object):
     @property
     def port(self):
         return self._port
+
+    @property
+    def external_dependencies(self):
+        return self._external_dependencies
 
     @property
     def longpolling_port(self):

--- a/odoo_env/odooenv.py
+++ b/odoo_env/odooenv.py
@@ -635,7 +635,7 @@ class OdooEnv(object):
         # que exponer los puertos.
         if not (self.nginx or write_config):
             command += '-p %s:8069 ' % self.client.port
-            command += '-p 8072:8072 '
+            command += '-p %s:8072 ' % self.client.longpolling_port
 
         command += self._add_normal_mountings()
         if self.debug:

--- a/odoo_env/odooenv.py
+++ b/odoo_env/odooenv.py
@@ -513,6 +513,23 @@ class OdooEnv(object):
 
         return ret
 
+    def install_external_dependencies(self, client_name):
+        ret = []
+        self._client = Client(self, client_name)
+        external_dependencies = self.client.external_dependencies()
+        if 'python' in external_dependencies:
+            pip_names = external_dependencies['python'].join(' ')
+ 
+            cmd = Command(
+                self,
+                command='sudo docker exec  {} pip install {}'.format(client_name, pip_names),
+                usr_msg='{} installing pip packages {} please wait...'.format(client_name, pip_names),
+            )
+            ret.append(cmd)            
+
+        return ret
+
+
     def stop_client(self, client_name):
         ret = []
 

--- a/odoo_env/odooenv.py
+++ b/odoo_env/odooenv.py
@@ -453,8 +453,8 @@ class OdooEnv(object):
         ##################################################################
 
         image = self.client.get_image('postgres')
-
-        msg = 'Starting postgres image v{}'.format(image.version)
+        if image:
+            msg = 'Starting postgres image v{}'.format(image.version)
 
         command = 'sudo docker run -d '
         if self.debug:
@@ -641,7 +641,8 @@ class OdooEnv(object):
         if self.debug:
             command += self._add_debug_mountings(self.client.numeric_ver)
 
-        command += '--link pg-%s:db ' % self.client.name
+        if self.client.get_image('postgres'):
+            command += '--link pg-%s:db ' % self.client.name
 
         if not (self.debug or write_config):
             command += '--restart=always '

--- a/odoo_env/odooenv.py
+++ b/odoo_env/odooenv.py
@@ -516,13 +516,13 @@ class OdooEnv(object):
     def install_external_dependencies(self, client_name):
         ret = []
         self._client = Client(self, client_name)
-        external_dependencies = self.client.external_dependencies()
-        if 'python' in external_dependencies:
-            pip_names = external_dependencies['python'].join(' ')
+        external_dependencies = self.client.external_dependencies
+        if 'python' in external_dependencies and len(external_dependencies['python']):
+            pip_names = (' ').join(external_dependencies['python'])
  
             cmd = Command(
                 self,
-                command='sudo docker exec  {} pip install {}'.format(client_name, pip_names),
+                command='sudo docker exec  {} pip install --upgrade {}'.format(client_name, pip_names),
                 usr_msg='{} installing pip packages {} please wait...'.format(client_name, pip_names),
             )
             ret.append(cmd)            

--- a/odoo_env/oe.py
+++ b/odoo_env/oe.py
@@ -54,8 +54,7 @@ Odoo Environment Manager v%s - by jeo Software <jorge.obiols@gmail.com>
     parser.add_argument(
         '-E', '--ext-dep',
         action='store_true',
-        help="Stop odoo image.")
-
+        help="Update manifest external dependecies.")
 
     parser.add_argument(
         '-u', '--update',

--- a/odoo_env/oe.py
+++ b/odoo_env/oe.py
@@ -52,6 +52,12 @@ Odoo Environment Manager v%s - by jeo Software <jorge.obiols@gmail.com>
         help="Stop odoo image.")
 
     parser.add_argument(
+        '-E', '--ext-dep',
+        action='store_true',
+        help="Stop odoo image.")
+
+
+    parser.add_argument(
         '-u', '--update',
         action='store_true',
         help="Update modules to database. Use --debug to force update with "
@@ -228,6 +234,9 @@ Odoo Environment Manager v%s - by jeo Software <jorge.obiols@gmail.com>
 
     if args.stop_cli:
         commands += OdooEnv(options).stop_client(client_name)
+
+    if args.ext_dep:
+        commands += OdooEnv(options).install_external_dependencies(client_name)
 
     if args.run_cli:
         commands += OdooEnv(options).run_client(client_name)


### PR DESCRIPTION
Este PR ayuda en modelos de despliege no contemplados hasta ahora
  - No es requerido el docker de postgresql si este no es necesario.Por ejemplo para despliegues que utilicen RDS
  - Expone  un puerto de longpolling diferente si esta especificado en el __manifest__.py. Por ejemplo para desplegar varias versiones de odoo a la ves
  - Mediante *oe -E* Instalo las dependencias externas (pip) definidas en el archivo __manifest__.py  de la misma manera que lo hace odoo.sh 